### PR TITLE
Target http port and color annotation to fields

### DIFF
--- a/src/main/kotlin/com/dashfwd/guiceexample/Annotations.kt
+++ b/src/main/kotlin/com/dashfwd/guiceexample/Annotations.kt
@@ -3,11 +3,11 @@ package com.dashfwd.guiceexample
 import com.google.inject.BindingAnnotation
 
 @BindingAnnotation
-@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER, AnnotationTarget.PROPERTY)
+@Target(AnnotationTarget.FIELD)
 @Retention(AnnotationRetention.RUNTIME) // required for Guice
 annotation class ColorAnnotation
 
 @BindingAnnotation
-@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER, AnnotationTarget.PROPERTY)
+@Target(AnnotationTarget.FIELD)
 @Retention(AnnotationRetention.RUNTIME) // required for Guice
 annotation class HttpPortAnnotation

--- a/src/main/kotlin/com/dashfwd/guiceexample/Services.kt
+++ b/src/main/kotlin/com/dashfwd/guiceexample/Services.kt
@@ -80,14 +80,14 @@ class PersonServiceImpl : PersonService {
     lateinit var msg: String
 
     @Inject
-    @ColorAnnotation
+    @field:ColorAnnotation
     lateinit var color: String
 
     @Inject
-    @HttpPortAnnotation
+    @field:HttpPortAnnotation
     var httpPort: String=""
 
-    override fun speak() = println("$msg; also did you know about the color $color? (port=$httpPort")
+    override fun speak() = println("$msg; also did you know about the color $color? (port=$httpPort)")
 }
 
 /**


### PR DESCRIPTION
Hey,

I think these annotations need to target the Kotlin field backing the property for guice to inject the values.